### PR TITLE
Fix nan values in scale term and coords artifacts in depthmap

### DIFF
--- a/code/cpp/include/depthmap_stitcher.hpp
+++ b/code/cpp/include/depthmap_stitcher.hpp
@@ -121,7 +121,7 @@ public:
 
 	// depth map's sub map filename regular expression
 	int index_digit_number = 3;
-	std::string depthmap_filename_regexp = "[a-zA-Z0-9\\_]*\\_depth\\_[0-9]{3}.pfm";
+	std::string depthmap_filename_regexp = "[a-zA-Z0-9\\_]*\\_disp\\_erp\\_[0-9]{3}.pfm";
 	std::string rgb_filename_regexp = "[a-zA-Z0-9\\_]*\\_rgb\\_[0-9]{3}.jpg";
 	std::string corr_filename_regexp = "[a-zA-Z0-9\\_]*\\_corr\\_[0-9]{3}\\_[0-9]{3}.json";
 	// pixels corresponding filename regular expression

--- a/code/cpp/src/depthmap_stitcher.cpp
+++ b/code/cpp/src/depthmap_stitcher.cpp
@@ -122,9 +122,9 @@ void DepthmapStitcher::load_data(const std::string& data_root_dir, const std::ve
 		intidx2extidx[index] = depthmap_extindex;
 	}
 	smatch m_prefixs;
-	regex_search(depthmap_filename_list[0], m_prefixs, std::regex("[a-zA-Z0-9]*_rgb"));
+	regex_search(depthmap_filename_list[0], m_prefixs, std::regex("[a-zA-Z0-9\\_]*\\_disp"));
 	std::string prefix = m_prefixs[0].str();
-	filename_prefix = prefix.substr(0, prefix.length());
+	filename_prefix = prefix.substr(0, prefix.length()-5);
 	LOG(INFO) << "File name prefix is " << filename_prefix;
 
 	// 1) load the pixel corresponding relationship

--- a/code/cpp/src/depthmap_stitcher_group.cpp
+++ b/code/cpp/src/depthmap_stitcher_group.cpp
@@ -201,9 +201,12 @@ struct DepthmapStitcherGroup::ScaleResidual {
 		T sum_number(0);
 		for (int index = 0; index < grid_width_ * grid_height_; index++)
 		{
-			sum_number += 1.0 / scale_list[index];
+			sum_number += 1.0 / (scale_list[index] + T(1e-10));
 		}
 		residual[0] = sum_number;
+//        if (ceres::isinf(residual[0]) || ceres::isnan(residual[0])){
+//            printf("INFINITY SCALE\n");
+//        }
 		return true;
 	}
 

--- a/code/cpp/src/depthmap_stitcher_group.cpp
+++ b/code/cpp/src/depthmap_stitcher_group.cpp
@@ -204,9 +204,9 @@ struct DepthmapStitcherGroup::ScaleResidual {
 			sum_number += 1.0 / (scale_list[index] + T(1e-10));
 		}
 		residual[0] = sum_number;
-//        if (ceres::isinf(residual[0]) || ceres::isnan(residual[0])){
-//            printf("INFINITY SCALE\n");
-//        }
+//      if (ceres::isinf(residual[0]) || ceres::isnan(residual[0])){
+//          printf("INFINITY SCALE\n");
+//      }
 		return true;
 	}
 


### PR DESCRIPTION
This commit avoid nan values in the scale term `1/scale` while also fixes some coordinates artifacts when projecting tangent images to ERP.

Focusing in the 1K input images (2048x1024) the north and south pole faces had vertical coordinate ranges [-1,x] and [x,1024] respectively. In the former that means the north pole faces have values at the south pole and vice versa, resulting in wrong blending weights. Originally this should be taken care of later in the code at `gp.inside_polygon_2d` but it is not working for some reason.

Also I add some small changes to speed up the computation of frustum blending weights. With more clean code.